### PR TITLE
Add template system

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ Tests können mit folgendem Skript ausgeführt werden:
 ./run_tests.sh
 ```
 
+## Templates
+
+Es stehen mehrere Projektvorlagen zur Verfügung, die im Verzeichnis
+`templates/` liegen. Mit dem `TemplateManager` lassen sich Projekte
+aus diesen Vorlagen erzeugen. Verfügbare Templates sind aktuell
+`smart_home`, `automation` und `game_dev`.
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,6 @@
-"""Project package."""
+"""project_generator package."""
+
+from .template_manager import TemplateManager
+from .venv_manager import VirtualEnvironmentManager
+
+__all__ = ["VirtualEnvironmentManager", "TemplateManager"]

--- a/src/template_manager.py
+++ b/src/template_manager.py
@@ -1,0 +1,35 @@
+"""Manage project templates."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from logging import Logger
+
+
+class TemplateManager:
+    """Handles creation of project folders from templates."""
+
+    def __init__(self, logger: Logger, templates_dir: Path | None = None):
+        self.logger = logger
+        self.templates_dir = templates_dir or Path(__file__).resolve().parent.parent / "templates"
+
+    def available_templates(self) -> list[str]:
+        """Return a list of available template names."""
+        if not self.templates_dir.exists():
+            return []
+        return [d.name for d in self.templates_dir.iterdir() if d.is_dir()]
+
+    def create_from_template(self, template_name: str, target_path: Path) -> bool:
+        """Copy a template into the target path."""
+        source = self.templates_dir / template_name
+        if not source.is_dir():
+            self.logger.error("Template '%s' does not exist", template_name)
+            return False
+        try:
+            shutil.copytree(source, target_path)
+            self.logger.info("Project created at %s", target_path)
+            return True
+        except Exception as exc:  # noqa: BLE001
+            self.logger.error("Failed to create project: %s", exc)
+            return False

--- a/src/venv_manager.py
+++ b/src/venv_manager.py
@@ -1,0 +1,67 @@
+"""Utility for creating Python virtual environments."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Optional
+from logging import Logger
+
+
+class VirtualEnvironmentManager:
+    """Manages creation of virtual environments."""
+
+    def __init__(self, logger: Logger, progress_callback: Optional[Callable[[str], None]] = None):
+        self.logger = logger
+        self.progress_callback = progress_callback
+
+    async def create_venv(self, project_path: Path) -> bool:
+        """Create a virtual environment in the given project path.
+
+        Returns True if creation succeeded or already exists, False otherwise.
+        """
+        venv_path = project_path / ".venv"
+        try:
+            if not self._validate_python_venv():
+                raise EnvironmentError("Python venv module not available")
+
+            if venv_path.exists():
+                self.logger.warning("venv already exists: %s", venv_path)
+                return True
+
+            if self.progress_callback:
+                self.progress_callback("Creating virtual environment...")
+
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-m",
+                "venv",
+                str(venv_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await process.communicate()
+            if process.returncode != 0:
+                raise subprocess.CalledProcessError(process.returncode, "venv", stderr)
+
+            self.logger.info("Virtual environment created at %s", venv_path)
+            if self.progress_callback:
+                self.progress_callback("Virtual environment ready")
+            return True
+        except Exception as exc:
+            self.logger.error("venv creation failed: %s", exc)
+            if venv_path.exists():
+                shutil.rmtree(venv_path)
+            return False
+
+    def _validate_python_venv(self) -> bool:
+        """Return True if venv module is available."""
+        try:
+            import venv  # noqa: F401
+
+            return True
+        except ImportError:
+            return False

--- a/templates/automation/README.md
+++ b/templates/automation/README.md
@@ -1,0 +1,3 @@
+# Automation Template
+
+Use this template for automation scripts.

--- a/templates/automation/pyproject.toml
+++ b/templates/automation/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "automation_project"
+version = "0.1.0"

--- a/templates/automation/requirements.txt
+++ b/templates/automation/requirements.txt
@@ -1,0 +1,1 @@
+# Automation dependencies

--- a/templates/automation/src/main.py
+++ b/templates/automation/src/main.py
@@ -1,0 +1,1 @@
+print("Hello from Automation template")

--- a/templates/game_dev/README.md
+++ b/templates/game_dev/README.md
@@ -1,0 +1,3 @@
+# Game Dev Template
+
+Template for starting a new game development project.

--- a/templates/game_dev/pyproject.toml
+++ b/templates/game_dev/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "game_dev_project"
+version = "0.1.0"

--- a/templates/game_dev/requirements.txt
+++ b/templates/game_dev/requirements.txt
@@ -1,0 +1,1 @@
+# Game dev requirements

--- a/templates/game_dev/src/main.py
+++ b/templates/game_dev/src/main.py
@@ -1,0 +1,1 @@
+print("Hello from Game Dev template")

--- a/templates/smart_home/README.md
+++ b/templates/smart_home/README.md
@@ -1,0 +1,3 @@
+# Smart Home Template
+
+This template sets up a simple smart home project.

--- a/templates/smart_home/pyproject.toml
+++ b/templates/smart_home/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "smart_home_project"
+version = "0.1.0"

--- a/templates/smart_home/requirements.txt
+++ b/templates/smart_home/requirements.txt
@@ -1,0 +1,1 @@
+# Add project dependencies here

--- a/templates/smart_home/src/main.py
+++ b/templates/smart_home/src/main.py
@@ -1,0 +1,1 @@
+print("Hello from Smart Home template")

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -1,0 +1,15 @@
+import logging
+from pathlib import Path
+
+from src.template_manager import TemplateManager
+
+
+def test_create_from_template(tmp_path: Path):
+    logger = logging.getLogger("test")
+    manager = TemplateManager(logger, Path("templates"))
+    assert "smart_home" in manager.available_templates()
+    target = tmp_path / "project"
+    result = manager.create_from_template("smart_home", target)
+    assert result
+    assert (target / "pyproject.toml").exists()
+    assert (target / "src" / "main.py").exists()

--- a/tests/test_venv_manager.py
+++ b/tests/test_venv_manager.py
@@ -1,0 +1,13 @@
+import asyncio
+import logging
+from pathlib import Path
+
+from src.venv_manager import VirtualEnvironmentManager
+
+
+def test_create_venv(tmp_path: Path):
+    logger = logging.getLogger("test")
+    manager = VirtualEnvironmentManager(logger)
+    result = asyncio.run(manager.create_venv(tmp_path))
+    assert result
+    assert (tmp_path / ".venv").exists()


### PR DESCRIPTION
## Summary
- introduce `TemplateManager` for handling project templates
- add example templates for smart_home, automation and game_dev
- expose `TemplateManager` through the package
- document templates in README
- test generating a project from a template

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68572f4e90a08324840a296127dccda6